### PR TITLE
Authorize cross origin requests

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -16,6 +16,7 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
+            new Nelmio\CorsBundle\NelmioCorsBundle(),
             new Nelmio\ApiDocBundle\NelmioApiDocBundle(),
             new FOS\OAuthServerBundle\FOSOAuthServerBundle(),
             new FOS\RestBundle\FOSRestBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -88,5 +88,14 @@ fos_rest:
     view:
         view_response_listener: true
 
+nelmio_cors:
+    paths:
+       "^/(api|oauth)/":
+          allow_credentials: true
+          allow_origin: ['*']
+          allow_headers: ['*']
+          allow_methods: ['*']
+          max_age: 3600
+
 nelmio_api_doc:
     name: Darkmira portal API

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
         "jms/serializer-bundle": "^1.2",
+        "nelmio/cors-bundle": "^1.5",
         "nelmio/api-doc-bundle": "^2.13.1",
         "friendsofsymfony/oauth-server-bundle": "^1.5",
         "friendsofsymfony/rest-bundle": "^2.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cf1d59327f32b2e53d4b4207a788242d",
-    "content-hash": "41e11ec3d46b26db4142099d6214a84b",
+    "hash": "a162c05fa39712e73c475d80d06070ed",
+    "content-hash": "4277f89cd0338e90564db664d5df8d2c",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1715,6 +1715,63 @@
                 "rest"
             ],
             "time": "2017-02-19 05:14:31"
+        },
+        {
+            "name": "nelmio/cors-bundle",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nelmio/NelmioCorsBundle.git",
+                "reference": "cc9a26517b65769e6e3cea10099d4a40ce11ca29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nelmio/NelmioCorsBundle/zipball/cc9a26517b65769e6e3cea10099d4a40ce11ca29",
+                "reference": "cc9a26517b65769e6e3cea10099d4a40ce11ca29",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/framework-bundle": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
+                "mockery/mockery": "0.9.*"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nelmio\\CorsBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nelmio",
+                    "homepage": "http://nelm.io"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/nelmio/NelmioCorsBundle/contributors"
+                }
+            ],
+            "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Symfony2 application",
+            "keywords": [
+                "api",
+                "cors",
+                "crossdomain"
+            ],
+            "time": "2017-01-22 21:34:09"
         },
         {
             "name": "paragonie/random_compat",


### PR DESCRIPTION
As web clients will request this API with ajax requests from other domain, browser will block the request for XSS security.

This PR adds Cors supports to allows other domains.