### PR TITLE
Fix Cors configuration

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -96,7 +96,7 @@ nelmio_cors:
           allow_credentials: true
           allow_origin: ['*']
           allow_headers: ['*']
-          allow_methods: ['*']
+          allow_methods: [GET, POST, PUT, PATCH, DELETE]
           max_age: 3600
 
 nelmio_api_doc:


### PR DESCRIPTION
In fact, `allow_methods: ['*']` is not working, it must have every method to be allowed, or not allows cross origin Ajax requests.